### PR TITLE
Update install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
  
  安装包:
  
-`npm i react-native-barCode --save`
+`npm i react-native-barcode --save`
 
 通过引用`import {BarCode,QRCode} from 'react-native-barcode-qrcode'`来使用
 


### PR DESCRIPTION
because npm i react-native-barCode --save caused:

npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "i" "react-native-barCode" "--save"
npm ERR! node v5.1.1
npm ERR! npm  v3.3.12
npm ERR! code E404

npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/react-native-barCode
npm ERR! 404 
npm ERR! 404 'react-native-barCode' is not in the npm registry.
npm ERR! 404 Your package name is not valid, because
npm ERR! 404 
npm ERR! 404  1. name can no longer contain capital letters